### PR TITLE
Fix CMake Shark issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/CMakeModules")
 find_package(Flut REQUIRED)
 
 # Shark 3.0 provides a SharkConfig.cmake.
-find_package(Shark 3.0 REQUIRED PATHS "${SHARK_ROOT}/lib/cmake/Shark")
+find_package(Shark 3.0 REQUIRED PATHS "${SHARK_ROOT}")
 
 # Link with boost's static libraries.
 set(Boost_USE_STATIC_LIBS OFF)


### PR DESCRIPTION
Remove need for separate Shark_ROOT variable. Tested on Windows and Unix. @tgeijten might want to check that it with your setup before merging since I did use Shark 3.0.1 instead of Shark 3.0.0. 
