### PR TITLE
print log when using SimulateObjective

### DIFF
--- a/scone/sconeopt/sconeopt.cpp
+++ b/scone/sconeopt/sconeopt.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
 		else if ( fileName.extension().string() == ".par" )
 		{
 			// if .par file given, evaluate the objective and print log
-            log::SetLevel( log::TraceLevel );
+			log::SetLevel( log::TraceLevel );
 			opt::SimulateObjective( fileName.string() );
 		}
 		else


### PR DESCRIPTION
Small change to keep old behavior when evaluating .par files
