### PR TITLE
change DATE_TIME_EXACT to include microseconds

### DIFF
--- a/scone/sconelib/scone/core/string_tools.cpp
+++ b/scone/sconelib/scone/core/string_tools.cpp
@@ -44,14 +44,15 @@ namespace scone
 
 	std::string GetDateTimeExactAsString()
 	{
-		auto now = boost::posix_time::second_clock::local_time();
+		auto now = boost::posix_time::microsec_clock::local_time();
 		auto month = static_cast<int>( now.date().month() );
 		auto day = static_cast<int>( now.date().day() );
 		auto hours = static_cast<int>( now.time_of_day().hours() );
 		auto mins = static_cast<int>( now.time_of_day().minutes() );
 		auto secs = static_cast<int>( now.time_of_day().seconds() );
+        auto frac_secs = static_cast<int>( now.time_of_day().fractional_seconds() );
 
-		return stringf( "%02d%02d.%02d%02d%02d", month, day, hours, mins, secs );
+		return stringf( "%02d%02d.%02d%02d%02d.%06d", month, day, hours, mins, secs, frac_secs );
 	}
 
 	String SCONE_API GetCleanVarName( const String& str )


### PR DESCRIPTION
directed at batching optimizations. there can be a case when schedulers on a cluster can send jobs to start so closely together that there will be a (silent) folder conflict when a second job will not see that a first job has created the same folder already.
