### PR TITLE
random_seed mechanism for ccmaes

### DIFF
--- a/scone/sconelib/scone/opt/CmaOptimizerCCMAES.cpp
+++ b/scone/sconelib/scone/opt/CmaOptimizerCCMAES.cpp
@@ -3,6 +3,7 @@
 #include "flut/optimizer/cma_optimizer.hpp"
 #include "flut/container_tools.hpp"
 #include <numeric>
+#include <random>
 #include "flut/string_tools.hpp"
 
 using std::cout;
@@ -24,6 +25,12 @@ namespace scone
 			size_t dim = par.GetFreeParamCount();
 
 			SCONE_ASSERT( dim > 0 );
+
+			// init random seed
+			if ( random_seed == 0 ) {
+				std::random_device rd;
+				random_seed = rd();
+			}
 
 			// initialize settings from file
 			if ( use_init_file && !init_file.empty() )


### PR DESCRIPTION
Allows `random_seed` to be generated randomly if denoted 0. Matches behavior as before. This was needed as I noticed that my optimizations starting within ~1 second from each other on the cluster yielded the same answers.

This may hint that a different change could be needed. Currently, assigning the same exact seed number to ccmaes will not ensure the same result in the end. This is because of [this method](https://github.com/tgeijten/flut/blob/512da4cf027cbc3f680a2ac6d114876126e123b4/flut/optimizer/cma_optimizer.cpp#L112), which uses the clock time to randomize the seed. Digging through the code, however, it looks like that method is only used to internally set a seed number, whereas we could set it directly.

TL;DR @tgeijten Small PR patch here should help my optimizations on the cluster. If you want me to look at simplifying the initial seed in flut's cma_optimizer, let me know.