### PR TITLE
bump flag to c++14 and remove stale String.h includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,21 +56,21 @@ include_directories(${CMAKE_SOURCE_DIR}/contrib/tclap-1.2.1/include)
 
 # Compiler flags.
 # ---------------
-# Must compile with C++11 with gcc/clang.
+# Must compile with C++14 with gcc/clang.
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR
    ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     if(APPLE)
         if(XCODE)
-            set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+            set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14")
             set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
         else()
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
             if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
             endif()
         endif()
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
     endif()
 endif()
 

--- a/scone/sconelib/scone/core/HasName.h
+++ b/scone/sconelib/scone/core/HasName.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core.h"
-#include "String.h"
 #include "Exception.h"
 #include <algorithm>
 #include <vector>

--- a/scone/sconelib/scone/core/HasSignature.h
+++ b/scone/sconelib/scone/core/HasSignature.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core.h"
-#include "String.h"
 #include "PropNode.h"
 
 namespace scone

--- a/scone/sconelib/scone/core/Log.h
+++ b/scone/sconelib/scone/core/Log.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core.h"
-#include "String.h"
 
 namespace scone
 {

--- a/scone/sconelib/scone/core/PropNode.h
+++ b/scone/sconelib/scone/core/PropNode.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core.h"
-#include "String.h"
 
 #include <memory>
 #include <vector>

--- a/scone/sconelib/scone/core/Storage.h
+++ b/scone/sconelib/scone/core/Storage.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core.h"
-#include "String.h"
 #include "Exception.h"
 
 #include <memory>

--- a/scone/sconelib/scone/core/string_tools.h
+++ b/scone/sconelib/scone/core/string_tools.h
@@ -4,7 +4,6 @@
 #include <iosfwd>
 
 #include "flut/string_tools.hpp"
-#include "String.h"
 
 // need for demangling with GCC
 #ifndef _MSC_VER


### PR DESCRIPTION
@tgeijten Along with the changes in the PR in flut, these changes seem to work fine. I did notice some slight changes to the progression of the optimizer in Tutorial 1 (needing more generations to approach previous best max values) on both Windows and Linux, but still seemed to be giving reasonable performance in a short test (~150 generations).

Note that this is a PR into the `reorganization` branch.