### PR TITLE
add a velocity range penalty option to GaitMeasure

### DIFF
--- a/scone/sconelib/scone/objectives/GaitMeasure.h
+++ b/scone/sconelib/scone/objectives/GaitMeasure.h
@@ -19,10 +19,12 @@ namespace scone
 
 		// parameters
 		Real termination_height;
+		Real min_max_velocity_weight;
 		Real min_velocity;
 		Real max_velocity;
 		Real load_threshold;
 		Real max_velocity_range;
+		Real max_velocity_range_weight;
 
 	protected:
 		virtual String GetClassSignature() const override;


### PR DESCRIPTION
@tgeijten This PR adds a penalty to GaitMeasure that penalizes a range violation if (highest_step_velocity - lowest_step_velocity) is greater than a threshold. Default behavior should not change current use of GaitMeasure (unless somehow the velocity range is greater than the speed of light...). Let me know if you'd like any changes in order to merge.