### PR TITLE
Add build_on_mac.sh

### DIFF
--- a/OpenSceneGraph_cpp11.patch
+++ b/OpenSceneGraph_cpp11.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d5552864e..ff784a9e0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1066,30 +1066,9 @@ ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+         # remain unset.
+ 
+         IF (APPLE)
+-            SET(OSG_CXX_LANGUAGE_STANDARD "C++11" CACHE STRING "set the c++ language standard (C++98 / GNU++98 / C++11) for OSG" )
++            SET(OSG_CXX_LANGUAGE_STANDARD "11" CACHE STRING "set the c++ language standard (98 / 11) for OSG" )
+             MARK_AS_ADVANCED(OSG_CXX_LANGUAGE_STANDARD)
+-            # remove existing flags
+-            REMOVE_CXX_FLAG(-std=c++98)
+-            REMOVE_CXX_FLAG(-std=gnu++98)
+-            REMOVE_CXX_FLAG(-std=c++11)
+-            REMOVE_CXX_FLAG(-stdlib=libstdc++)
+-            REMOVE_CXX_FLAG(-stdlib=libc++)
+-
+-            IF(${OSG_CXX_LANGUAGE_STANDARD} STREQUAL "c++98" OR ${OSG_CXX_LANGUAGE_STANDARD} STREQUAL "C++98")
+-                set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++98")
+-                set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libstdc++")
+-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98 -stdlib=libstdc++")
+-            ELSE()
+-                IF(${OSG_CXX_LANGUAGE_STANDARD} STREQUAL "gnu++98" OR ${OSG_CXX_LANGUAGE_STANDARD} STREQUAL "GNU++98")
+-                    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "gnu++98")
+-                    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libstdc++")
+-                    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++98 -stdlib=libstdc++")
+-                ELSE()
+-                    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+-                    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+-                    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+-                ENDIF()
+-            ENDIF()
++            SET(CMAKE_CXX_STANDARD ${OSG_CXX_LANGUAGE_STANDARD})
+ 
+             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual -Wno-conversion")
+             set(WARNING_CFLAGS "")
+diff --git a/src/osgPlugins/CMakeLists.txt b/src/osgPlugins/CMakeLists.txt
+index ca24ff801..b6692a3ca 100644
+--- a/src/osgPlugins/CMakeLists.txt
++++ b/src/osgPlugins/CMakeLists.txt
+@@ -80,7 +80,7 @@ ADD_SUBDIRECTORY(vtf)
+ ADD_SUBDIRECTORY(ktx)
+ 
+ IF(JPEG_FOUND)
+-    ADD_SUBDIRECTORY(jpeg)
++    # TODO ADD_SUBDIRECTORY(jpeg)
+ ENDIF()
+ IF(JASPER_FOUND)
+     ADD_SUBDIRECTORY(jp2)

--- a/build_on_mac.sh
+++ b/build_on_mac.sh
@@ -1,0 +1,95 @@
+# First, install cmake and qt5 via Homebrew.
+# brew install cmake qt5
+
+# Simbody
+mkdir ../simbody
+cd ../simbody
+git clone https://github.com/simbody/simbody.git
+cd simbody
+git checkout Simbody-3.6.1
+mkdir ../build
+cd ../build
+cmake ../simbody \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
+    -DCMAKE_RELEASE_POSTFIX="OpenSim4.0" \
+    -DBUILD_TESTING=off \
+    -DBUILD_EXAMPLES=off
+make --jobs 4 install
+cd ../../scone
+
+# OpenSim
+mkdir ../opensim-core
+cd ../opensim-core
+git clone https://github.com/opensim-org/opensim-core.git
+cd opensim-core
+git checkout 4.0
+mkdir ../build
+cd ../build
+cmake ../opensim-core \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
+    -DCMAKE_RELEASE_POSTFIX="4.0" \
+    -DSIMBODY_HOME=../../simbody/install \
+    -DBUILD_API_ONLY=on
+make --jobs 4 install
+cd ../../scone
+
+# OpenSceneGraph
+mkdir ../OpenSceneGraph
+cd ../OpenSceneGraph
+git clone https://github.com/openscenegraph/OpenSceneGraph.git
+cd OpenSceneGraph
+git checkout OpenSceneGraph-3.5.4
+git apply ../../scone/OpenSceneGraph_cpp11.patch
+mkdir ../build
+cd ../build
+cmake ../OpenSceneGraph \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10
+make --jobs 4 install
+cd ../../scone
+
+# osgQt
+mkdir ../osgQt
+cd ../osgQt
+git clone https://github.com/openscenegraph/osgQt.git
+mkdir build
+cd build
+cmake ../osgQt \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
+    -DCMAKE_PREFIX_PATH=/usr/local/opt/qt # From Homebrew.
+make --jobs 4 install
+cd ../../scone
+
+# # SCONE
+git submodule update --init
+mkdir ../build
+cd ../build
+cmake ../scone \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$(pwd)/../install \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
+    -DCMAKE_PREFIX_PATH="/usr/local/opt/qt;$(pwd)/../opensim-core/install" \
+    -DOSGQT_INCLUDE_DIR=$(pwd)/../osgQt/install/include \
+    -DOSGQT_LIBRARY_RELEASE=$(pwd)/../osgQt/install/lib/libosgQt5.dylib \
+    -DOSG_DIR="$(pwd)/../OpenSceneGraph/install"
+make --jobs 4
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds a draft of a script for building SCONE and its dependencies on Mac.

I couldn't compile SCONE. Here is one of the errors I got:

```cpp
/Users/chris/repos/scone/2/scone/submodules/xo/xo/container/circular_frame_buffer.h:35:25: error:
      use of undeclared identifier 'frame_count'
                        xo_assert( frame0 >= frame_count() - frame_buf_size...
                                             ^
/Users/chris/repos/scone/2/scone/submodules/xo/xo/container/circular_frame_buffer.h:35:69: error:
      use of undeclared identifier 'frame_count'
  ...xo_assert( frame0 >= frame_count() - frame_buf_size_ && frame0 < frame_coun...
```