### PR TITLE
initialize "offset" property in BodyMeasure

### DIFF
--- a/src/sconelib/scone/measures/BodyMeasure.cpp
+++ b/src/sconelib/scone/measures/BodyMeasure.cpp
@@ -18,6 +18,7 @@ namespace scone
 	body( *FindByLocation( model.GetBodies(), props.get< String >( "body" ), loc ) ),
 	range_count( 0 )
 	{
+		INIT_PROP( props, offset, Vec3::zero() );
 		INIT_PROP( props, axes_weights, Vec3::zero() );
 		INIT_PROP( props, relative_to_model_com, false );
 		INIT_PROP( props, position, RangePenalty< Real >() );


### PR DESCRIPTION
@tgeijten Looks like "offset" property isn't initialized/used for BodyMeasure in 0.21.0. I think this should fix that.