### PR TITLE
fix DATE_TIME_EXACT to parse correctly

### DIFF
--- a/src/sconelib/scone/core/HasSignature.cpp
+++ b/src/sconelib/scone/core/HasSignature.cpp
@@ -20,10 +20,10 @@ namespace scone
 		INIT_PROP( pn, signature_postfix, String("") );
 
 		// replace DATE_TIME tag with (yes, indeed) DATE and TIME
-		xo::replace_str( signature_prefix, "DATE_TIME", GetDateTimeAsString() );
-		xo::replace_str( signature_postfix, "DATE_TIME", GetDateTimeAsString() );
 		xo::replace_str( signature_prefix, "DATE_TIME_EXACT", GetDateTimeExactAsString() );
 		xo::replace_str( signature_postfix, "DATE_TIME_EXACT", GetDateTimeExactAsString() );
+		xo::replace_str( signature_prefix, "DATE_TIME", GetDateTimeAsString() );
+		xo::replace_str( signature_postfix, "DATE_TIME", GetDateTimeAsString() );
 		xo::replace_str( signature_prefix, "SCONE_BUILD", to_str( GetSconeVersion().build ) );
 		xo::replace_str( signature_postfix, "SCONE_BUILD", to_str( GetSconeVersion().build ) );
 		xo::replace_str( signature_prefix, "SCONE_VERSION", to_str( GetSconeVersion().build ) );


### PR DESCRIPTION
Since DATE_TIME is replaced before DATE_TIME_EXACT, you get folder names like this:
`19042.152027_EXACT.modelname...`

This branch re-orders the calls so that DATE_TIME_EXACT is handled first.