### PR TITLE
ContactGeometry.h: fix initialization of m_Scale from a single radius value

### DIFF
--- a/src/sconelib/scone/model/ContactGeometry.h
+++ b/src/sconelib/scone/model/ContactGeometry.h
@@ -9,7 +9,7 @@ namespace scone
 	struct ContactGeometry
 	{
 		enum Shape { Unknown, Sphere, Box, Plane };
-		ContactGeometry( const Body& b, const Vec3& p, double radius ) : m_Body( b ), m_Shape( Sphere ), m_Pos( p ), m_Scale( radius ) {}
+		ContactGeometry( const Body& b, const Vec3& p, double radius ) : m_Body( b ), m_Shape( Sphere ), m_Pos( p ), m_Scale( Vec3( radius, radius, radius ) ) {}
 		ContactGeometry( const Body& b, Shape s, const Vec3& p, const Quat& q, const Vec3& scale ) : m_Body( b ), m_Shape( s ), m_Pos( p ), m_Ori( q ), m_Scale( scale ) {}
 		const Body& m_Body;
 		Shape m_Shape;


### PR DESCRIPTION
Alternatively, could add another constructor in `xo/vec3_type.h`. I chose this way since it didn't change the `Vec3` constructor interface, but I wasn't sure what your vision for that class is.