### PR TITLE
Muscle reflex allow neg

### DIFF
--- a/install/install_win32.nsi
+++ b/install/install_win32.nsi
@@ -1,0 +1,158 @@
+;NSIS Modern User Interface
+;Start Menu Folder Selection Example Script
+;Written by Joost Verburg
+
+!define SCONE_VERSION "1.4.0"
+!define MSVC_VERSION "vc2017-x86"
+!define BIN_FOLDER "..\bin\${MSVC_VERSION}\Release"
+!define OSG_PLUGINS_FOLDER "osgPlugins-3.4.1"
+!define SCONE_DOCUMENTS_FOLDER "$DOCUMENTS\SCONE"
+!define VCREDIST_FILE "vc_redist.x86.exe"
+
+;--------------------------------
+;Include Modern UI
+!include "MUI2.nsh"
+
+;--------------------------------
+;General
+
+;Name and file
+Name "SCONE"
+OutFile "SCONE-${SCONE_VERSION}.exe"
+SetCompressor /SOLID lzma
+
+;Default installation folder
+InstallDir "$PROGRAMFILES64\SCONE"
+
+;Get installation folder from registry if available
+InstallDirRegKey HKCU "Software\SCONE\INSTDIR" ""
+
+;Request application privileges for Windows Vista
+RequestExecutionLevel admin
+
+;--------------------------------
+;Variables
+Var StartMenuFolder
+
+;--------------------------------
+;Interface Settings
+
+!define MUI_HEADERIMAGE
+!define MUI_HEADERIMAGE_BITMAP "install_header.bmp" ; optional
+!define MUI_ABORTWARNING
+
+;--------------------------------
+;Pages
+
+;!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "license.txt"
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_DIRECTORY
+  
+;Start Menu Folder Page Configuration
+!define MUI_STARTMENUPAGE_REGISTRY_ROOT "HKCU" 
+!define MUI_STARTMENUPAGE_REGISTRY_KEY "Software\SCONE" 
+!define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "Start Menu Folder"
+  
+!insertmacro MUI_PAGE_STARTMENU Application $StartMenuFolder
+  
+!insertmacro MUI_PAGE_INSTFILES
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+;--------------------------------
+;Languages
+ 
+!insertmacro MUI_LANGUAGE "English"
+
+;--------------------------------
+;Installer Sections
+
+Section "Program Files" SecMain
+	; root folder
+	SetOverwrite on
+	SetOutPath "$INSTDIR"
+	File "..\.version"
+	
+	; bin files
+	SetOutPath "$INSTDIR\bin"
+	File "${BIN_FOLDER}\*.exe"
+	File "${BIN_FOLDER}\*.dll"
+	File "${VCREDIST_FILE}"
+	SetOutPath "$INSTDIR\bin\${OSG_PLUGINS_FOLDER}"
+	File "${BIN_FOLDER}\${OSG_PLUGINS_FOLDER}\*.dll"
+	SetOutPath "$INSTDIR\bin\platforms"
+	File "${BIN_FOLDER}\platforms\*.dll"
+	
+	; resource files
+	SetOutPath "$INSTDIR\resources"
+	File /r "..\resources\*.*"
+
+	; Store installation folder
+	WriteRegStr HKCU "Software\SCONE\INSTDIR" "" $INSTDIR
+	WriteRegStr HKCU "Software\SCONE\DOCDIR" "" ${SCONE_DOCUMENTS_FOLDER}
+
+	; Create uninstaller
+	WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+	!insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+
+	; Create shortcuts
+	CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
+	CreateShortCut "$SMPROGRAMS\$StartMenuFolder\SCONE.lnk" "$INSTDIR\bin\sconestudio.exe"
+	CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Uninstall SCONE.lnk" "$INSTDIR\Uninstall.exe"
+	
+	; Install VC Redistributables
+	ExecWait `"$INSTDIR\bin\${VCREDIST_FILE}" /quiet`
+
+	!insertmacro MUI_STARTMENU_WRITE_END
+SectionEnd
+
+Section "Examples" SecTutorials
+	; scenarios
+	SetOutPath "${SCONE_DOCUMENTS_FOLDER}\Tutorials"
+	File /r "..\scenarios\Tutorials\*.*"
+SectionEnd
+
+; Set section to read-only
+Function .onInit
+  IntOp $0 ${SF_SELECTED} | ${SF_RO}
+  SectionSetFlags ${SecMain} $0
+FunctionEnd
+
+;--------------------------------
+;Descriptions
+
+	;Language strings
+	LangString DESC_SecMain ${LANG_ENGLISH} "Files needed to run SCONE"
+	;LangString DESC_SecModels ${LANG_ENGLISH} "Example OpenSim models"
+	LangString DESC_SecTutorials ${LANG_ENGLISH} "SCONE tutorials and examples"
+
+	;Assign language strings to sections
+	!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+		!insertmacro MUI_DESCRIPTION_TEXT ${SecMain} $(DESC_SecMain)
+		;!insertmacro MUI_DESCRIPTION_TEXT ${SecModels} $(DESC_SecModels)
+		!insertmacro MUI_DESCRIPTION_TEXT ${SecTutorials} $(DESC_SecTutorials)
+	!insertmacro MUI_FUNCTION_DESCRIPTION_END
+ 
+;--------------------------------
+;Uninstaller Section
+
+Section "Uninstall"
+
+  ;ADD YOUR OWN FILES HERE...
+  Delete "$INSTDIR\Uninstall.exe"
+  RMDir "$INSTDIR"
+  
+  !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
+    
+  Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\SCONE.lnk"
+  RMDir "$SMPROGRAMS\$StartMenuFolder"
+  
+  DeleteRegKey /ifempty HKCU "Software\SCONE\INSTDIR"
+  DeleteRegKey /ifempty HKCU "Software\SCONE\DOCDIR"
+
+SectionEnd

--- a/src/sconelib/scone/controllers/MuscleReflex.cpp
+++ b/src/sconelib/scone/controllers/MuscleReflex.cpp
@@ -29,7 +29,7 @@ namespace scone
 
 		INIT_PAR( props, par, KL, 0.0 );
 		INIT_PAR( props, par, L0, 1.0 );
-		INIT_PROP( props, allow_neg_L, false );
+		INIT_PROP( props, allow_neg_L, true );
 
 		INIT_PAR( props, par, KV, 0.0 );
 		INIT_PAR( props, par, V0, 0.0 );
@@ -37,7 +37,7 @@ namespace scone
 
 		INIT_PAR( props, par, KF, 0.0 );
 		INIT_PAR( props, par, F0, 0.0 );
-		INIT_PROP( props, allow_neg_F, false );
+		INIT_PROP( props, allow_neg_F, true );
 
 		INIT_PAR( props, par, KS, 0.0 );
 		INIT_PAR( props, par, S0, 0.0 );

--- a/src/sconelib/scone/controllers/MuscleReflex.cpp
+++ b/src/sconelib/scone/controllers/MuscleReflex.cpp
@@ -29,7 +29,7 @@ namespace scone
 
 		INIT_PAR( props, par, KL, 0.0 );
 		INIT_PAR( props, par, L0, 1.0 );
-		INIT_PROP( props, allow_neg_L, true );
+		INIT_PROP( props, allow_neg_L, false );
 
 		INIT_PAR( props, par, KV, 0.0 );
 		INIT_PAR( props, par, V0, 0.0 );
@@ -37,7 +37,7 @@ namespace scone
 
 		INIT_PAR( props, par, KF, 0.0 );
 		INIT_PAR( props, par, F0, 0.0 );
-		INIT_PROP( props, allow_neg_F, true );
+		INIT_PROP( props, allow_neg_F, false );
 
 		INIT_PAR( props, par, KS, 0.0 );
 		INIT_PAR( props, par, S0, 0.0 );

--- a/src/sconelib/scone/controllers/MuscleReflex.h
+++ b/src/sconelib/scone/controllers/MuscleReflex.h
@@ -37,14 +37,14 @@ namespace scone
 		Real KF;
 		/// Force feedback offset; default = 0.
 		Real F0;
-		/// Allow this reflex to be negative; default = 0.
+		/// Allow this reflex to be negative; default = 1 (please note that you might want this to be 0 if offset is defined).
 		bool allow_neg_F;
 
 		/// Length feedback gain, based on normalized CE length (L / Lopt); default = 0.
 		Real KL;
 		/// Length feedback offset; default = 1.
 		Real L0;
-		/// Allow this reflex to be negative; default = 0.
+		/// Allow this reflex to be negative; default = 1 (please note that you might want this to be 0 if offset is defined).
 		bool allow_neg_L;
 
 		/// Velocity feedback gain, based on normalized CE velocity ((L / Lopt) / s); default = 0.

--- a/src/sconelib/scone/controllers/MuscleReflex.h
+++ b/src/sconelib/scone/controllers/MuscleReflex.h
@@ -37,35 +37,35 @@ namespace scone
 		Real KF;
 		/// Force feedback offset; default = 0.
 		Real F0;
-		/// Allow this reflex to be negative; default = 1.
+		/// Allow this reflex to be negative; default = 0.
 		bool allow_neg_F;
 
 		/// Length feedback gain, based on normalized CE length (L / Lopt); default = 0.
 		Real KL;
 		/// Length feedback offset; default = 1.
 		Real L0;
-		/// Allow this reflex to be negative; default = 1.
+		/// Allow this reflex to be negative; default = 0.
 		bool allow_neg_L;
 
 		/// Velocity feedback gain, based on normalized CE velocity ((L / Lopt) / s); default = 0.
 		Real KV;
 		/// Velocity feedback offset; default = 0.
 		Real V0;
-		/// Allow this reflex to be negative; default = 1.
+		/// Allow this reflex to be negative; default = 0.
 		bool allow_neg_V;
 
 		/// Muscle activation feedback gain, based on normalized activation; default = 0.
 		Real KA;
 		/// Activation feedback offset; default = 0.
 		Real A0;
-		/// Allow this reflex to be negative; default = 1.
+		/// Allow this reflex to be negative; default = 0.
 		bool allow_neg_A;
 
 		/// Spindle feedback gain, based on [Prochazka 1999], p.135; default = 0.
 		Real KS;
 		/// Spindle feedback offset; default = 0.
 		Real S0;
-		/// Allow this reflex to be negative; default = 1.
+		/// Allow this reflex to be negative; default = 0.
 		bool allow_neg_S;
 
 		virtual void StoreData( Storage< Real >::Frame& frame, const StoreDataFlags& flags ) const override;

--- a/src/sconelib/scone/controllers/MuscleReflex.h
+++ b/src/sconelib/scone/controllers/MuscleReflex.h
@@ -15,9 +15,9 @@
 namespace scone
 {
 	/// Reflex based on muscle length, muscle velocity, muscle force, or muscle spindle sensor.
-	/// 
+	///
 	/// Must be part of ReflexController. Output excitation corresponds to
-	/// ''U = _C0_ + [_KF(F - F0)_]<sub>+</sub> + [_KL(L - L0)_]<sub>+</sub> + [_KV(V - V0)_]<sub>+</sub> + [_KS(S - S0)_]<sub>+</sub>'',
+	/// ''U = _C0_ + _KF[(F - F0)_]<sub>+</sub> + _KL[(L - L0)_]<sub>+</sub> + _KV[(V - V0)_]<sub>+</sub> + _KS[(S - S0)_]<sub>+</sub>'',
 	/// where []<sub>+</sub> indicates a result is always >= 0, unless the corresponding allow_neg_* is set to 1.
 	class MuscleReflex : public Reflex
 	{
@@ -82,8 +82,9 @@ namespace scone
 	private:
 		Real GetValue( SensorDelayAdapter* s, Real gain, Real ofs, bool allow_neg ) {
 			if ( s ) {
-				Real value = gain * ( s->GetValue( delay ) - ofs );
-				return ( !allow_neg && value < 0.0 ) ? 0.0 : value;
+				Real sensoryFeedback = ( s->GetValue( delay ) - ofs );
+				sensoryFeedback = ( !allow_neg && sensoryFeedback < 0.0 ) ? 0.0 : sensoryFeedback;
+				return gain * sensoryFeedback;
 			}
 			else return 0.0;
 		}

--- a/src/sconelib/scone/model/muscle_tools.cpp
+++ b/src/sconelib/scone/model/muscle_tools.cpp
@@ -26,7 +26,13 @@ namespace scone
 	DofRangeVec GetDofRangeVec( const Dof& dof, Real increment )
 	{
 		auto range = xo::frange( GetDofBounds( dof ), increment );
-		return DofRangeVec( range.begin(), range.end() );
+
+		// DofRangeVec{ range.begin(), range.end() } does not work with MVSC 2017
+		DofRangeVec result;
+		for (auto r : range)
+			result.push_back(r);
+
+		return result;
 	}
 
 	std::vector<Real> GetDofInfo( Dof& dof, const DofRangeVec& range, std::function<Real()> func ) {

--- a/src/sconestudio/CMakeLists.txt
+++ b/src/sconestudio/CMakeLists.txt
@@ -191,7 +191,19 @@ if(${Qt5Widgets_FOUND})
 	
 		# Copy all OpenSim3 DLLs
 		if (SCONE_OPENSIM_3)
-			SET(OPENSIM_DLLS osimTools osimAnalyses osimActuators osimSimulation osimLepton osimCommon SimTKsimbody SimTKmath SimTKcommon)
+			# check if platform is x86 or x64 (OpenSim has different names for dynamic library depending on the ABI)
+			if(${CMAKE_SIZEOF_VOID_P} EQUAL 8) # check if x64
+				set(PTHREAD pthreadVC2_x64)
+				set(LIBGCC libgcc_s_sjlj-1)
+				set(NameSpace "")
+			else() # else x86
+				set(PTHREAD pthreadVC2)
+				set(LIBGCC libgcc_s_dw2-1)
+				set(NameSpace "OpenSim_")
+			endif()
+
+			SET(OPENSIM_DLLS osimTools osimAnalyses osimActuators osimSimulation osimLepton osimCommon 
+				${NameSpace}SimTKsimbody ${NameSpace}SimTKmath ${NameSpace}SimTKcommon)
 			foreach(opensimdll ${OPENSIM_DLLS})
 				add_custom_command(TARGET sconestudio POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${OPENSIM_INSTALL_DIR}/bin/${opensimdll}$<$<CONFIG:debug>:_d>.dll ${DLL_TARGET_DIR}
@@ -199,7 +211,7 @@ if(${Qt5Widgets_FOUND})
 			endforeach()
 
 			# Copy extra opensim files
-			SET(OPENSIM_EXTRA_DLLS libblas liblapack libgcc_s_sjlj-1 libgfortran-3 libquadmath-0 pthreadVC2_x64)
+			SET(OPENSIM_EXTRA_DLLS libblas liblapack ${LIBGCC} libgfortran-3 libquadmath-0 ${PTHREAD})
 			foreach(opensimdll ${OPENSIM_EXTRA_DLLS})
 				add_custom_command(TARGET sconestudio POST_BUILD
 					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${OPENSIM_INSTALL_DIR}/bin/${opensimdll}.dll ${DLL_TARGET_DIR}


### PR DESCRIPTION
This addresses issue  #192. The muscle reflex was changed in a manner such as:

1. The default behavior of every reflex is allow_neg = 0
2. Only the part inside the parenthesis is checked for the sign convention.

Furthermore, I tried to build the installer on Windows x86 and I had to fix a couple issues related to different names for the dlls of OpenSim 3.3 x86 (pthread and libgcc). 

In case that you want to merge this, please verify that the changes in CMakeLists.txt do not break the Windows installer for x64.

Can you please point out which versions of zlib and libpng do you use? I used GnuWin32.