### PR TITLE
added sorting result folders by date and deleting a folder or file

### DIFF
--- a/src/sconestudio/SconeStudio.cpp
+++ b/src/sconestudio/SconeStudio.cpp
@@ -203,6 +203,9 @@ bool SconeStudio::init()
 	ui.resultsBrowser->setRoot( to_qt( results_folder ), "*.par;*.sto" );
 	ui.resultsBrowser->header()->setFrameStyle( QFrame::NoFrame | QFrame::Plain );
 
+	ui.resultsBrowser->setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(ui.resultsBrowser, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(onResultBrowserCustomContextMenu(const QPoint &)));
+
 	connect( ui.resultsBrowser->selectionModel(),
 		SIGNAL( currentChanged( const QModelIndex&, const QModelIndex& ) ),
 		this, SLOT( selectBrowserItem( const QModelIndex&, const QModelIndex& ) ) );
@@ -283,6 +286,7 @@ void SconeStudio::activateBrowserItem( QModelIndex idx )
 
 void SconeStudio::selectBrowserItem( const QModelIndex& idx, const QModelIndex& idxold )
 {
+	currResultModelIdx = idx;
 	auto item = ui.resultsBrowser->fileSystemModel()->fileInfo( idx );
 	string dirname = item.isDir() ? item.filePath().toStdString() : item.dir().path().toStdString();
 }
@@ -967,4 +971,72 @@ void SconeStudio::finalizeCapture()
 	delete captureProcess;
 	captureProcess = nullptr;
 	captureFilename.clear();
+}
+
+void SconeStudio::deleteSelectedFileOrFolder()
+{
+	if (!currResultModelIdx.isValid()) return;
+
+	int ret = QMessageBox::warning(this, tr("Delete file or folder"), 
+		tr("Do you really want to delete the selected file or folder (can not be recovered)"), 
+		QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+	if (ret == QMessageBox::Cancel) {
+		return;
+	}
+
+	auto item = ui.resultsBrowser->fileSystemModel()->fileInfo(currResultModelIdx);
+	string dirname = item.isDir() ? item.filePath().toStdString() : item.dir().path().toStdString();
+
+	if (item.isDir()) {
+		bool succ = ui.resultsBrowser->fileSystemModel()->rmdir(currResultModelIdx);
+		if (!succ) {
+			//can not remove non empty folder
+			QDir dir(item.filePath());
+			succ = dir.removeRecursively();
+
+			if (!succ) {
+				QMessageBox::information(this, tr("Message"), tr("can not delete folder"), QMessageBox::Ok);
+			}
+		}
+	}
+	else if (item.isFile()) {
+		bool succ = ui.resultsBrowser->fileSystemModel()->remove(currResultModelIdx);
+		if (!succ) {
+			QMessageBox::information(this, tr("Message"), tr("can not delete file"), QMessageBox::Ok);
+		}
+	}
+	else {
+
+	}
+}
+
+void SconeStudio::sortFileOrFolderByDate()
+{
+	ui.resultsBrowser->fileSystemModel()->sort(3);
+}
+
+void SconeStudio::sortFileOrFolderByName()
+{
+	ui.resultsBrowser->fileSystemModel()->sort(0);
+}
+
+void SconeStudio::onResultBrowserCustomContextMenu(const QPoint &pos)
+{
+	QModelIndex idx = ui.resultsBrowser->indexAt(pos);
+	currResultModelIdx = idx;
+
+	QMenu menu;
+	QAction *deleteAct = new QAction("Delete", this);
+	connect(deleteAct, SIGNAL(triggered()), this, SLOT(deleteSelectedFileOrFolder()));
+	menu.addAction(deleteAct);
+
+	QAction *sortDataAct = new QAction("Sort by name", this);
+	connect(sortDataAct, SIGNAL(triggered()), this, SLOT(sortFileOrFolderByName()));
+	menu.addAction(sortDataAct);
+
+	QAction *sortNameAct = new QAction("Sort by date", this);
+	connect(sortNameAct, SIGNAL(triggered()), this, SLOT(sortFileOrFolderByDate()));
+	menu.addAction(sortNameAct);
+
+	menu.exec(ui.resultsBrowser->mapToGlobal(pos));
 }

--- a/src/sconestudio/SconeStudio.h
+++ b/src/sconestudio/SconeStudio.h
@@ -98,6 +98,11 @@ public slots:
 	void toggleComments() { if ( auto* e = getActiveCodeEditor() ) e->toggleComments(); }
 	void resetWindowLayout();
 
+	void deleteSelectedFileOrFolder();
+	void sortFileOrFolderByDate();
+	void sortFileOrFolderByName();
+	void onResultBrowserCustomContextMenu(const QPoint &);
+
 public:
 	bool close_all;
 	bool isRecording() { return !captureFilename.isEmpty(); }
@@ -156,6 +161,8 @@ private:
 	// gait analysis
 	scone::GaitAnalysis* gaitAnalysis;
 	QDockWidget* gaitAnalysisDock;
+
+	QModelIndex currResultModelIdx;
 
 	// parameters
 	QTableView* parView;


### PR DESCRIPTION
Oftentimes there are too many folders in the results section after running different cases and sometimes it is hard to remember which ones are the latest. I thought maybe adding a functionality to sort the folders by date will be helpful. In addition, it will be convenient to delete some folders with meaningless or non optimal results from the GUI directly. So I added a right mouse click menu on directory tree of the Optimization Results panel. Hopefully this could be useful and others can further improve it. Thanks. 