### PR TITLE
Source code formatting style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+﻿---
+AlignTrailingComments: 'false'
+BreakBeforeBraces: Allman
+IndentWidth: '4'
+Language: Cpp
+NamespaceIndentation: Inner
+PointerAlignment: Left
+SpaceAfterLogicalNot: 'true'
+SpaceAfterTemplateKeyword: 'true'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeCpp11BracedList: 'true'
+SpaceBeforeCtorInitializerColon: 'true'
+SpaceBeforeInheritanceColon: 'true'
+SpaceBeforeParens: Always
+SpaceBeforeRangeBasedForLoopColon: 'true'
+SpaceInEmptyParentheses: 'true'
+SpacesInAngles: 'true'
+SpacesInCStyleCastParentheses: 'true'
+SpacesInContainerLiterals: 'true'
+SpacesInParentheses: 'true'
+SpacesInSquareBrackets: 'true'
+TabWidth: '4'
+UseTab: Always
+
+...


### PR DESCRIPTION
You might want to include a .clang-format in the SCONE project so that independently of the editor used the code formatting should follow the rules that you prefer. I tried to setup a .clang-format file based on the style that you use.

https://zed0.co.uk/clang-format-configurator/

This is very useful, because I use a different coding style and every time I tried to work with SCONE, I have to change some settings in my editor. With the .clang-format file this is done automatically independent of the editor.