### PR TITLE
Make getinstallfolder use local static

### DIFF
--- a/src/sconelib/scone/core/system_tools.cpp
+++ b/src/sconelib/scone/core/system_tools.cpp
@@ -18,28 +18,33 @@
 #include "Log.h"
 #include "Exception.h"
 
+namespace {
+	using scone::path;
+
+	path GetInstallFolderUncached()
+	{
+		path p = xo::get_application_dir();
+		for ( ; !p.empty(); p = p.parent_path() )
+		{
+			path config = p / ".sconeroot";
+			if ( xo::exists( config ) )
+			{
+				return xo::load_string( config );
+			}
+			else if ( xo::exists( p / ".version" ) )
+				break;
+		}
+		SCONE_THROW_IF( p.empty(), "Could not detect installation root folder, please run .updateversion.bat or .updateversion.sh" );
+		scone::log::debug( "SCONE root folder: ", p );
+		return p;
+	}
+}
+
 namespace scone
 {
-	String g_Version;
-	path g_RootFolder;
-
 	path GetInstallFolder()
 	{
-		if ( g_RootFolder.empty() )
-		{
-			for ( g_RootFolder = xo::get_application_dir(); !g_RootFolder.empty(); g_RootFolder = g_RootFolder.parent_path() )
-			{
-				if ( xo::exists( g_RootFolder / ".sconeroot" ) )
-				{
-					g_RootFolder = xo::load_string( g_RootFolder / ".sconeroot" );
-					break;
-				}
-				else if ( xo::exists( g_RootFolder / ".version" ) )
-					break;
-			}
-			SCONE_THROW_IF( g_RootFolder.empty(), "Could not detect installation root folder, please run .updateversion.bat or .updateversion.sh" );
-			log::debug( "SCONE root folder: ", g_RootFolder );
-		}
+		static const path g_RootFolder = GetInstallFolderUncached();
 		return g_RootFolder;
 	}
 

--- a/src/sconelib/scone/core/system_tools.cpp
+++ b/src/sconelib/scone/core/system_tools.cpp
@@ -41,7 +41,7 @@ namespace {
 
 namespace scone
 {
-	path GetInstallFolder()
+	const path& GetInstallFolder()
 	{
 		static const path g_RootFolder = FindInstallFolder();
 		return g_RootFolder;

--- a/src/sconelib/scone/core/system_tools.cpp
+++ b/src/sconelib/scone/core/system_tools.cpp
@@ -21,7 +21,7 @@
 namespace {
 	using scone::path;
 
-	path GetInstallFolderUncached()
+	path FindInstallFolder()
 	{
 		path p = xo::get_application_dir();
 		for ( ; !p.empty(); p = p.parent_path() )
@@ -44,7 +44,7 @@ namespace scone
 {
 	path GetInstallFolder()
 	{
-		static const path g_RootFolder = GetInstallFolderUncached();
+		static const path g_RootFolder = FindInstallFolder();
 		return g_RootFolder;
 	}
 

--- a/src/sconelib/scone/core/system_tools.cpp
+++ b/src/sconelib/scone/core/system_tools.cpp
@@ -26,8 +26,7 @@ namespace {
 		path p = xo::get_application_dir();
 		for ( ; !p.empty(); p = p.parent_path() )
 		{
-			path config = p / ".sconeroot";
-			if ( xo::exists( config ) )
+			if ( path config = p / ".sconeroot"; xo::exists( config ) )
 			{
 				return xo::load_string( config );
 			}

--- a/src/sconelib/scone/core/system_tools.h
+++ b/src/sconelib/scone/core/system_tools.h
@@ -16,8 +16,8 @@ namespace scone
 	using xo::path;
 
 	enum SconeFolder { SCONE_ROOT_FOLDER, SCONE_RESULTS_FOLDER, SCONE_MODEL_FOLDER, SCONE_SCENARIO_FOLDER, SCONE_RESOURCE_FOLDER, SCONE_GEOMETRY_FOLDER, SCONE_UI_RESOURCE_FOLDER };
-	SCONE_API const path& GetSettingsFolder();
-	SCONE_API path GetInstallFolder();
+	SCONE_API path GetSettingsFolder();
+	SCONE_API const path& GetInstallFolder();
 	SCONE_API path GetDataFolder();
 	SCONE_API path GetFolder( SconeFolder folder );
 	SCONE_API path FindFile( const path& filename );

--- a/src/sconelib/scone/core/system_tools.h
+++ b/src/sconelib/scone/core/system_tools.h
@@ -16,7 +16,7 @@ namespace scone
 	using xo::path;
 
 	enum SconeFolder { SCONE_ROOT_FOLDER, SCONE_RESULTS_FOLDER, SCONE_MODEL_FOLDER, SCONE_SCENARIO_FOLDER, SCONE_RESOURCE_FOLDER, SCONE_GEOMETRY_FOLDER, SCONE_UI_RESOURCE_FOLDER };
-	SCONE_API path GetSettingsFolder();
+	SCONE_API const path& GetSettingsFolder();
 	SCONE_API path GetInstallFolder();
 	SCONE_API path GetDataFolder();
 	SCONE_API path GetFolder( SconeFolder folder );


### PR DESCRIPTION
I noticed that some `g_RootFolder` is being checked whether it's empty or not each time GetInstallFolder is called. 

One, mostly paranoid, suggestion I'd make is to leverage the fact that function-local static variables are guaranteed to be initialized when the function is called for the first time *and* are thread-safe, so there's no risk of two threads stomping a global during initialization.

This isn't a bugfix, or functionally changing the behavior of the app, and the thread-safe consideration is an extreme edge-case, so this PR is purely a stylistic change (and can be ignored if you don't think it's worth a merge).