### PR TITLE
Always grab 'master' opensim3

### DIFF
--- a/tools/linux_1_get-dependencies
+++ b/tools/linux_1_get-dependencies
@@ -74,7 +74,7 @@ echo "installing fpm: used to create end-user packages (e.g. .deb)"
 ${sudo} gem install --no-document fpm
 
 try_clone_checkout "https://github.com/openscenegraph/OpenSceneGraph.git" "OpenSceneGraph-3.4.1"
-try_clone_checkout "https://github.com/tgeijten/opensim3-scone.git" "de8ebaed846e"
+try_clone_checkout "https://github.com/tgeijten/opensim3-scone.git" "master"
 try_clone_checkout "https://github.com/simbody/simbody.git" "Simbody-3.5.4"
 
 echo "git submodules: initializing and updating"


### PR DESCRIPTION
Minor change, which makes the linux build always grab `master` for `opensim3-scone`.

This is probably a bad thing for the build history, because it can mean that checking out this same commit in the future produces a different build (because `master` changes over time). However, it means that e.g. @tgeijten can update `opensim3-scone` and just re-run SCONE's CI without having to also update SCONE to point to a new version (e.g. as is necessary with `git submodule`s.

If we're worried about this then I could make things such that the opensim3 build is strongly-versioned, but overridable (e.g. set `OPENSIM3_TAG=master` if we want to just pull latest).