### PR TITLE
Support for boolean options

### DIFF
--- a/src/sconelib/sconeopensim3/ModelOpenSim3.cpp
+++ b/src/sconelib/sconeopensim3/ModelOpenSim3.cpp
@@ -431,6 +431,11 @@ namespace scone
 					vec3_prop->updValue() = to_osim( scenario_value );
 				else SCONE_ERROR( "Unsupported qualifier " + prop_qualifier + " for " + os_object.getName() + "." + prop_key + "" );
 			}
+			else if (os_prop.getTypeName() == "bool")
+			{
+				os_prop.updValue<bool>() = prop_val.get<bool>();
+			}
+
 			else if ( os_prop.isObjectProperty() )
 			{
 				log::debug( "Setting Parameter ", os_prop.getName() );


### PR DESCRIPTION
A small fix to support boolean options. For example, you might want to enable/disable a muscle:

```
Properties {
	hamstrings_r {isDisabled = true}
}
```