### PR TITLE
Fix an early termination of the mimic measure due to a mistake in the default value

### DIFF
--- a/src/sconelib/scone/measures/MimicMeasure.cpp
+++ b/src/sconelib/scone/measures/MimicMeasure.cpp
@@ -22,8 +22,8 @@ namespace scone
 		INIT_MEMBER( pn, include_states, xo::pattern_matcher( "*" ) ),
 		INIT_MEMBER( pn, exclude_states, xo::pattern_matcher( "" ) ),
 		INIT_MEMBER( pn, use_best_match, false ),
-		INIT_MEMBER( pn, average_error_limit, 1 ),
-		INIT_MEMBER( pn, peak_error_limit, 1 )
+		INIT_MEMBER( pn, average_error_limit, 1e9 ),
+		INIT_MEMBER( pn, peak_error_limit, 1e9 )
 	{
 		SCONE_PROFILE_FUNCTION( model.GetProfiler() );
 		ReadStorageSto( storage_, file );


### PR DESCRIPTION
Fix an early termination of the mimic measure due to a mistake in the default value.