### PR TITLE
CMake downgrade to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(scone)
 

--- a/src/sconelib/scone/measures/MimicMeasure.cpp
+++ b/src/sconelib/scone/measures/MimicMeasure.cpp
@@ -22,8 +22,8 @@ namespace scone
 		INIT_MEMBER( pn, include_states, xo::pattern_matcher( "*" ) ),
 		INIT_MEMBER( pn, exclude_states, xo::pattern_matcher( "" ) ),
 		INIT_MEMBER( pn, use_best_match, false ),
-		INIT_MEMBER( pn, average_error_limit, 1 ),
-		INIT_MEMBER( pn, peak_error_limit, 1 )
+		INIT_MEMBER( pn, average_error_limit, 1e9 ),
+		INIT_MEMBER( pn, peak_error_limit, 1e9 )
 	{
 		SCONE_PROFILE_FUNCTION( model.GetProfiler() );
 		ReadStorageSto( storage_, file );


### PR DESCRIPTION
For compatibility with Ubuntu18.04 which uses CMake 3.10 as its default version. Can you please update the references for xo, spot and vis? Thanks!