### PR TITLE
Permit multiple evaluations; make noise random

### DIFF
--- a/src/sconelib/scone/controllers/NoiseController.cpp
+++ b/src/sconelib/scone/controllers/NoiseController.cpp
@@ -10,16 +10,20 @@
 #include "scone/model/Model.h"
 #include "scone/model/Actuator.h"
 #include "scone/core/string_tools.h"
+#include <chrono>
+
+using std::chrono::high_resolution_clock;
 
 namespace scone
 {
 	NoiseController::NoiseController( const PropNode& props, Params& par, Model& model, const Location& loc ) :
-	Controller( props, par, model, loc ),
-	random_seed( props.get< unsigned int >( "random_seed", 123 ) ),
-	rng_( random_seed )
+	Controller( props, par, model, loc )
 	{
 		INIT_PROP( props, base_noise, 0 );
 		INIT_PROP( props, proportional_noise, 0 );
+		INIT_PROP( props, random_seed,
+				   high_resolution_clock::now().time_since_epoch().count() );
+		rng_ = xo::random_number_generator( random_seed );
 	}
 
 	bool NoiseController::ComputeControls( Model& model, double timestamp )

--- a/src/sconelib/scone/controllers/NoiseController.h
+++ b/src/sconelib/scone/controllers/NoiseController.h
@@ -27,7 +27,7 @@ namespace scone
 		/// Proportional standard deviation of the normal distribution; default = 0.
 		double proportional_noise;
 
-		/// Random seed for noise sampling; default = 123.
+		/// Random seed for noise sampling; default = time dependent.
 		unsigned int random_seed;
 
 	protected:

--- a/src/sconelib/scone/controllers/PerturbationController.cpp
+++ b/src/sconelib/scone/controllers/PerturbationController.cpp
@@ -11,14 +11,15 @@
 #include "scone/core/string_tools.h"
 #include "xo/numerical/math.h"
 #include "scone/core/Log.h"
+#include <chrono>
+
+using std::chrono::high_resolution_clock;
 
 namespace scone
 {
 	PerturbationController::PerturbationController( const PropNode& props, Params& par, Model& model, const Location& target_area ) :
 		Controller( props, par, model, target_area ),
 		body( *FindByName( model.GetBodies(), props.get< String >( "body" ) ) ),
-		random_seed( props.get( "random_seed", 5489 ) ),
-		rng_( random_seed ),
 		active_( false ),
 		current_force(),
 		current_moment()
@@ -28,6 +29,9 @@ namespace scone
 		INIT_PROP( props, position_offset, Vec3::zero() );
 		INIT_PROP( props, interval, xo::bounds<TimeInSeconds>( 0, 0 ) );
 		INIT_PROP( props, duration, xo::bounds<TimeInSeconds>( 0.1, 0.1 ) );
+		INIT_PROP( props, random_seed,
+				   high_resolution_clock::now().time_since_epoch().count() );
+		rng_ = xo::random_number_generator( random_seed );
 
 		SCONE_THROW_IF( !interval.is_null() && duration.upper > interval.lower, "Duration cannot be longer than interval" );
 		SCONE_ERROR_IF( !model.GetFeatures().allow_external_forces, "External forces are not enabled for this model, please add:\n\nuse_external_forces = 1" );

--- a/src/sconelib/scone/controllers/PerturbationController.h
+++ b/src/sconelib/scone/controllers/PerturbationController.h
@@ -38,7 +38,7 @@ namespace scone
 		/// Perturbation moment to apply; default = [ 0 0 0 ].
 		Vec3 moment;
 
-		/// Random seed used for the perturbation sequence; default = 5489.
+		/// Random seed used for the perturbation sequence; default = time dependent.
 		unsigned int random_seed;
 
 		/// Fixed time [s] between two perturbations; default 2.

--- a/src/sconelib/scone/optimization/ModelObjective.h
+++ b/src/sconelib/scone/optimization/ModelObjective.h
@@ -18,6 +18,11 @@ namespace scone
 	class SCONE_API ModelObjective : public Objective
 	{
 	public:
+		// Number of evaluations for reporting a result (default = 1). The worst
+		// results among all evaluations is reported back. This helps creating
+		// robust solutions.
+		int num_evaluations_to_report;
+		
 		ModelObjective( const PropNode& props, const path& find_file_folder );
 		virtual ~ModelObjective() = default;
 


### PR DESCRIPTION
Please feel free to close this PR if you do not like these changes. It is related to issue #236. 

I have made the perturbation and noise random by default. Otherwise, it always applies the same sequence of perturbations.

Also, you can choose if you want to evaluate the model multiple times. The worst result among all runs is reported back. This strategy did not solve the issue of transferring .par files to another machine. However, I think it could help make the controller robust if noise is included in the simulation so that each evaluation is different.